### PR TITLE
Don't panic on websocket transient errors

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -31,8 +31,11 @@ func Stream(k *Keep, e exchange.IBotExchange, s Strategy) error {
 
 	// This goroutine never, I repeat, *never* finishes.
 	for data := range ws.ToRoutine {
-		if err := handleData(k, e, s, data); err != nil {
-			return err
+		err := handleData(k, e, s, data)
+		if err != nil {
+			What(log.Error().
+				Err(err),
+				"error handling data")
 		}
 	}
 


### PR DESCRIPTION
Some websocket errors will surface occasionally (eg. Binance out of
order update ids), in this case we want to log those errors but not
crash the whole service.

Fixes https://github.com/numus-digital/ebstrategy/issues/20