### PR TITLE
Pin golangci-lint to 1.42.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         args: --timeout=2m
-        version: latest
+        version: v1.42.1


### PR DESCRIPTION
We're not ready yet for 1.43, lots of new warnings.